### PR TITLE
ci: automate docs policy bypass for dependabot workflow bumps

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Enforce docs updates when workflows/scripts change
         env:
           BASE_REF: ${{ github.base_ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         shell: bash
         run: |
           set -euo pipefail
@@ -69,6 +70,27 @@ jobs:
 
           echo "Changed files:"
           echo "$changed_files"
+
+          if ! echo "$changed_files" | grep -Eq '^(scripts/|\.github/workflows/)'; then
+            echo "No scripts/workflows changes requiring docs updates."
+            exit 0
+          fi
+
+          # Dependabot workflow version bumps can be high-volume and low-risk.
+          # Allow these through without docs changes when they only touch workflow files.
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ] \
+            && echo "$changed_files" | grep -Eq '^\.github/workflows/' \
+            && ! echo "$changed_files" | grep -Eq '^scripts/'; then
+            non_workflow_changes="$(
+              echo "$changed_files" \
+                | grep -Ev '^(\.github/workflows/|\.github/dependabot\.yml)$' \
+                || true
+            )"
+            if [ -z "$non_workflow_changes" ]; then
+              echo "Dependabot workflow-only update detected; skip docs change requirement."
+              exit 0
+            fi
+          fi
 
           if echo "$changed_files" | grep -Eq '^(scripts/|\.github/workflows/)'; then
             if echo "$changed_files" | grep -Eq '^(README\.md|\.github/FLYWHEEL\.md|docs/)'; then


### PR DESCRIPTION
## Summary\n- update docs-change-policy to auto-allow Dependabot PRs that only change workflow/dependabot files\n- keep strict docs requirement for scripts/ changes and non-workflow changes\n\n## Why\nDependabot action version bumps in .github/workflows were repeatedly blocked by docs-change-policy even when no docs-relevant logic changed.\n\n## Validation\n- check yaml pre-commit passed\n- policy remains strict for scripts/ and non-doc workflow edits