### PR TITLE
ci: fix dependabot workflow-only docs exemption matcher

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -83,7 +83,7 @@ jobs:
             && ! echo "$changed_files" | grep -Eq '^scripts/'; then
             non_workflow_changes="$(
               echo "$changed_files" \
-                | grep -Ev '^(\.github/workflows/|\.github/dependabot\.yml)$' \
+                | grep -Ev '^(\.github/workflows/.*|\.github/dependabot\.yml)$' \
                 || true
             )"
             if [ -z "$non_workflow_changes" ]; then

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -94,7 +94,8 @@ This runbook describes how to operate and recover Flywheel automation safely.
    ```
 3. Keep `.github/FLYWHEEL.md` aligned with policy and `README.md` aligned with operator entrypoints.
 
-### Dependabot Actor Naming
+### Dependabot Workflow Exemption
 
 - `docs-change-policy` treats both `dependabot[bot]` and `app/dependabot` as Dependabot actors.
-- Workflow-only dependency bumps from these actors are auto-exempt from docs update requirements.
+- Workflow-only means files under `.github/workflows/*` and optional `.github/dependabot.yml`.
+- These workflow-only bot updates are auto-exempt from docs update requirements.


### PR DESCRIPTION
## Summary\n- fix docs-change-policy workflow-only matcher to handle files under .github/workflows/*\n- keep allowlist for optional .github/dependabot.yml\n- document the behavior in runbook\n\n## Why\nThe previous matcher only matched the literal path  and failed for real files like .