### PR TITLE
fix: enforce real winner merge and expand hygiene scan

### DIFF
--- a/.github/workflows/candidate-pr-hygiene.yml
+++ b/.github/workflows/candidate-pr-hygiene.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: "72"
         type: string
+      scan_limit:
+        description: "How many open PRs to scan for candidate hygiene"
+        required: false
+        default: "1000"
+        type: string
 
 permissions:
   contents: read
@@ -44,6 +49,7 @@ jobs:
       KEEP_PER_ISSUE: ${{ inputs.keep_per_issue || '1' }}
       MIN_AGE_HOURS: ${{ inputs.min_age_hours || '12' }}
       CLOSE_SINGLETON_AFTER_HOURS: ${{ inputs.close_singleton_after_hours || '72' }}
+      SCAN_LIMIT: ${{ inputs.scan_limit || '1000' }}
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && (inputs.dry_run && 'true' || 'false') || 'false' }}
       GH_PAGER: cat
       PAGER: cat
@@ -59,7 +65,8 @@ jobs:
           cmd=(python scripts/shared/cleanup_candidate_prs.py \
             --keep-per-issue "$KEEP_PER_ISSUE" \
             --min-age-hours "$MIN_AGE_HOURS" \
-            --close-singleton-after-hours "$CLOSE_SINGLETON_AFTER_HOURS")
+            --close-singleton-after-hours "$CLOSE_SINGLETON_AFTER_HOURS" \
+            --limit "$SCAN_LIMIT")
 
           if [[ "$DRY_RUN" == "true" ]]; then
             cmd+=(--dry-run)

--- a/.github/workflows/flywheel-orchestrator.yml
+++ b/.github/workflows/flywheel-orchestrator.yml
@@ -484,8 +484,9 @@ jobs:
           done
 
           if [ "$merged_count" -eq 0 ]; then
-            echo "No eligible winner merged; skip scorecard validation."
-            exit 0
+            echo "No eligible winner merged from eligible set: $ELIGIBLE_CSV"
+            echo "Failing merge job to prevent false-positive success without real merge."
+            exit 1
           fi
           if [ "$merged_count" -gt 1 ]; then
             echo "Unexpected: multiple merged winners among eligible candidates."

--- a/docs/generated/workflow-inputs.md
+++ b/docs/generated/workflow-inputs.md
@@ -25,6 +25,7 @@ Run `uv run python scripts/check_docs_sync.py --generate` after workflow changes
 | `dry_run` | `false` | `True` | `boolean` | Only report close candidates without closing PRs |
 | `keep_per_issue` | `false` | `1` | `string` | How many newest candidate PRs to keep per issue |
 | `min_age_hours` | `false` | `12` | `string` | Only close duplicates older than this age (hours) |
+| `scan_limit` | `false` | `1000` | `string` | How many open PRs to scan for candidate hygiene |
 
 ## `ci-failure-auto-fix.yml`
 

--- a/scripts/shared/cleanup_candidate_prs.py
+++ b/scripts/shared/cleanup_candidate_prs.py
@@ -118,7 +118,7 @@ def main() -> None:
     parser.add_argument("--keep-per-issue", type=int, default=1)
     parser.add_argument("--min-age-hours", type=int, default=12)
     parser.add_argument("--close-singleton-after-hours", type=int, default=72)
-    parser.add_argument("--limit", type=int, default=200)
+    parser.add_argument("--limit", type=int, default=1000)
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
 

--- a/scripts/shared/select_merge_eligible.py
+++ b/scripts/shared/select_merge_eligible.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.parse
@@ -12,6 +13,9 @@ from pathlib import Path
 from typing import Any
 
 ALLOWED_CHECK_CONCLUSIONS = {"success", "neutral", "skipped"}
+BRANCH_PATTERN = re.compile(
+    r"^claude/issue-(?P<issue>\d+)-candidate-(?P<candidate>\d+)-(?P<run>\d+)$"
+)
 
 
 def _api_get(url: str, token: str, accept: str = "application/vnd.github+json") -> Any:
@@ -42,6 +46,76 @@ def _find_open_pr_by_head(repo: str, owner: str, branch: str, token: str) -> dic
         if isinstance(first, dict):
             return first
     return None
+
+
+def _parse_candidate_branch(branch: str) -> tuple[int, int, int] | None:
+    match = BRANCH_PATTERN.match(branch)
+    if not match:
+        return None
+    return (int(match.group("issue")), int(match.group("candidate")), int(match.group("run")))
+
+
+def _list_open_issue_candidate_prs(repo: str, issue_number: str, token: str) -> list[dict[str, Any]]:
+    issue_int = int(issue_number)
+    page = 1
+    per_page = 100
+    selected: list[dict[str, Any]] = []
+    while True:
+        url = f"https://api.github.com/repos/{repo}/pulls?state=open&per_page={per_page}&page={page}"
+        payload = _api_get(url, token)
+        if not isinstance(payload, list) or not payload:
+            break
+
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            head = item.get("head")
+            if not isinstance(head, dict):
+                continue
+            ref = head.get("ref")
+            if not isinstance(ref, str):
+                continue
+            parsed = _parse_candidate_branch(ref)
+            if parsed is None:
+                continue
+            parsed_issue, parsed_candidate, _ = parsed
+            if parsed_issue != issue_int:
+                continue
+            if parsed_candidate not in {1, 2, 3}:
+                continue
+            selected.append(item)
+
+        if len(payload) < per_page:
+            break
+        page += 1
+
+    return selected
+
+
+def _pick_latest_per_candidate(prs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest: dict[int, dict[str, Any]] = {}
+    for pr in prs:
+        if not isinstance(pr, dict):
+            continue
+        head = pr.get("head")
+        if not isinstance(head, dict):
+            continue
+        ref = head.get("ref")
+        if not isinstance(ref, str):
+            continue
+        parsed = _parse_candidate_branch(ref)
+        if parsed is None:
+            continue
+        _, candidate_id, _ = parsed
+        current = latest.get(candidate_id)
+        if current is None:
+            latest[candidate_id] = pr
+            continue
+        pr_updated = str(pr.get("updated_at", ""))
+        current_updated = str(current.get("updated_at", ""))
+        if pr_updated >= current_updated:
+            latest[candidate_id] = pr
+    return [latest[cid] for cid in sorted(latest)]
 
 
 def _status_checks_ok(repo: str, sha: str, token: str) -> bool:
@@ -114,14 +188,35 @@ def main() -> int:
         return 2
 
     owner = repo.split("/", 1)[0]
-    eligible_prs: list[int] = []
-
+    candidate_pool: list[dict[str, Any]] = []
+    seen_numbers: set[int] = set()
     for candidate_id in (1, 2, 3):
         branch = f"claude/issue-{issue_number}-candidate-{candidate_id}-{run_id}"
         pr = _find_open_pr_by_head(repo, owner, branch, token)
         if not pr:
             continue
+        number = pr.get("number")
+        if not isinstance(number, int):
+            continue
+        if number in seen_numbers:
+            continue
+        candidate_pool.append(pr)
+        seen_numbers.add(number)
 
+    # Fallback to cross-run candidates for this issue to avoid stale backlog when
+    # current run cannot provide >=2 eligible candidates.
+    if len(candidate_pool) < 2:
+        for pr in _pick_latest_per_candidate(_list_open_issue_candidate_prs(repo, issue_number, token)):
+            number = pr.get("number")
+            if not isinstance(number, int):
+                continue
+            if number in seen_numbers:
+                continue
+            candidate_pool.append(pr)
+            seen_numbers.add(number)
+
+    eligible_prs: list[int] = []
+    for pr in candidate_pool:
         head = pr.get("head", {})
         sha = head.get("sha") if isinstance(head, dict) else None
 
@@ -132,7 +227,8 @@ def main() -> int:
             continue
 
         number = pr.get("number")
-        assert isinstance(number, int)
+        if not isinstance(number, int):
+            continue
         eligible_prs.append(number)
 
     eligible_csv = ",".join(str(n) for n in eligible_prs)

--- a/scripts/shared/select_merge_eligible.py
+++ b/scripts/shared/select_merge_eligible.py
@@ -55,13 +55,17 @@ def _parse_candidate_branch(branch: str) -> tuple[int, int, int] | None:
     return (int(match.group("issue")), int(match.group("candidate")), int(match.group("run")))
 
 
-def _list_open_issue_candidate_prs(repo: str, issue_number: str, token: str) -> list[dict[str, Any]]:
+def _list_open_issue_candidate_prs(
+    repo: str, issue_number: str, token: str
+) -> list[dict[str, Any]]:
     issue_int = int(issue_number)
     page = 1
     per_page = 100
     selected: list[dict[str, Any]] = []
     while True:
-        url = f"https://api.github.com/repos/{repo}/pulls?state=open&per_page={per_page}&page={page}"
+        url = (
+            f"https://api.github.com/repos/{repo}/pulls?state=open&per_page={per_page}&page={page}"
+        )
         payload = _api_get(url, token)
         if not isinstance(payload, list) or not payload:
             break
@@ -206,7 +210,9 @@ def main() -> int:
     # Fallback to cross-run candidates for this issue to avoid stale backlog when
     # current run cannot provide >=2 eligible candidates.
     if len(candidate_pool) < 2:
-        for pr in _pick_latest_per_candidate(_list_open_issue_candidate_prs(repo, issue_number, token)):
+        for pr in _pick_latest_per_candidate(
+            _list_open_issue_candidate_prs(repo, issue_number, token)
+        ):
             number = pr.get("number")
             if not isinstance(number, int):
                 continue


### PR DESCRIPTION
## Summary
- fail merge job when no eligible winner is actually merged
- add deterministic fallback merge path in scripts/merge.py using arbiter scorecard winner
- allow cross-run candidate selection fallback in select_merge_eligible.py
- expand candidate hygiene scan limit to 1000 and expose workflow input
- sync generated workflow input docs

## Validation
- python -m compileall scripts/merge.py scripts/shared/select_merge_eligible.py scripts/shared/cleanup_candidate_prs.py
- uv run ruff check scripts/merge.py scripts/shared/select_merge_eligible.py scripts/shared/cleanup_candidate_prs.py
- dry-run verified hygiene script scans >200 candidates when limit=1000